### PR TITLE
Added 'config' option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,8 @@ module.exports = options => {
 			debug: options.debug === true,
 			silent: options.silent === true,
 			markdown: options.markdown !== false,
-			marked: options.marked
+			marked: options.marked,
+			config: options.config
 		});
 
 		if (!isGenerated) {

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ gulp.task('doc', () => {
 ### Options
 
 - **template**: Directory with the template files.
+- **config**: Directory containing config file (apidoc.json).
 - **debug (false)**: Show debug output.
 - **silent (false)**: Hide log output.
 - **markdown (true)**: Parse markdown statements in the documentation.


### PR DESCRIPTION
Without `config` option, if the source directory differs from config directory, I get:

```
warn: Please create an apidoc.json configuration file.
```

in the output.

`config` is a standard apidoc option, so I added it and used.